### PR TITLE
Fix steps for building mingw for Windows cross-compiling

### DIFF
--- a/source/en/latest/developer/build-windows.markdown
+++ b/source/en/latest/developer/build-windows.markdown
@@ -45,7 +45,7 @@ If you do not have a MinGW toolchain with at least GCC 5.x, then you must compil
   - git clone https://github.com/HandBrake/HandBrake.git
   - cd HandBrake
   - cd scripts
-  - ./mingw-w64-build x86_64 ./home/<my_user>/toolchains/
+  - ./mingw-w64-build x86_64 /home/&lt;my_user&gt;/toolchains/
   
 This process will take a few minutes, then provide you with a command which you can use to add the toolchain to your path.
  


### PR DESCRIPTION
There were two small issues here, firstly it was specifying a relative instead of absolute path. Also it wasn't rendering the `<my_user>` part in the output (on both GitHub and the docs site) so it just looked like `./home//toolchains/`.