### PR TITLE
Typo in headline

### DIFF
--- a/source/docs/en/latest/advanced/subtitles.markdown
+++ b/source/docs/en/latest/advanced/subtitles.markdown
@@ -18,12 +18,12 @@ License_URL:     https://handbrake.fr/docs/license.html
 Subtitles
 =============================
 
-## Supported Subtitle Foramts
+## Supported Subtitle Formats
 
 There are different types of subtitles that exist: 
-- Bitmaps (Pictures), e.g. DVD VOBSUBs, Bluray PGS
-- Text with markup, e.g. Closed Captions and SRT files.
-- Styled SSA, e.g. most anime subtitles in MKV files
+* Bitmaps (Pictures), e.g. DVD VOBSUBs, Bluray PGS
+* Text with markup, e.g. Closed Captions and SRT files.
+* Styled SSA, e.g. most anime subtitles in MKV files
 
 HandBrake can read subtitles from the following sources
 * From DVD’s – Either embedded VOBSUB or CC tracks. 
@@ -34,8 +34,8 @@ HandBrake can read subtitles from the following sources
 ## Supported Output Formats
 
 HandBrake has two methods of subtitle OUTPUT: 
-- Hard Burn: This means the subtitles are written on top of the image permanently. They cannot be turned on or off like on the DVD.
-- Soft Subtitles:  This means the subtitles will appear as separate selectable tracks in your output file. With the correct playback software, you’ll be able to enable / disable these subtitles as required.
+* Hard Burn: This means the subtitles are written on top of the image permanently. They cannot be turned on or off like on the DVD.
+* Soft Subtitles: This means the subtitles will appear as separate selectable tracks in your output file. With the correct playback software, you’ll be able to enable / disable these subtitles as required.
 
 The following subtitle types as supported as follows:
 


### PR DESCRIPTION
Small typo fixed. Also note that not all md clients render prefixed '-' as a bullet.