### PR TITLE
Update Fedora docs for changes in Fedora 27

### DIFF
--- a/source/docs/en/latest/developer/install-dependencies-fedora.markdown
+++ b/source/docs/en/latest/developer/install-dependencies-fedora.markdown
@@ -45,7 +45,7 @@ Dependencies:
 - patch
 - python
 - tar
-- x264-devel
+- x264-devel (requires [RPM Fusion Free](https://rpmfusion.org/) repository)
 - yasm
 - zlib-devel
 
@@ -59,7 +59,8 @@ Graphical interface dependencies:
 - intltool
 - libgudev1-devel
 - libnotify-devel
-- webkitgtk3-devel
+- webkitgtk3-devel (Fedora 26 and lower)
+- webkitgtk4-devel (Fedora 27 and higher)
 
 Install dependencies.
 
@@ -69,8 +70,16 @@ Install dependencies.
 
 To build the GTK [GUI](abbr:Graphical User Interface), install the graphical interface dependencies.
 
+Fedora 26 and lower:
+
     sudo yum groupinstall "X Software Development" "GNOME Software Development"
     sudo yum install dbus-glib-devel gstreamer1-devel gstreamer1-plugins-base-devel intltool libgudev1-devel libnotify-devel webkitgtk3-devel
+
+Fedora 27 and higher:
+
+    sudo yum groupinstall "X Software Development" "GNOME Software Development"
+    sudo yum install dbus-glib-devel gstreamer1-devel gstreamer1-plugins-base-devel intltool libgudev1-devel libnotify-devel webkitgtk4-devel
+
 
 Fedora is now prepared to build HandBrake. See [Building HandBrake for Linux](build-linux.html) for further instructions.
 


### PR DESCRIPTION
Update the developer dependency installation docs
for Fedora to account for updated in Fedora 27.

 - Mention the need to enable the RPM Fusion Free repository for the x264-devel package
 - Update dependency list to include webkitgtk4-devel
 - Separate installation command for Fedora lt 27 and Fedora gt 26 to account for package differences

Let me know if you want this ported to https://github.com/HandBrake/HandBrake-docs/tree/master/source/docs/en/1.0.0 also and I will update my pull request.