### PR TITLE
Clarification of --stop-at.

### DIFF
--- a/source/docs/en/1.2.0/cli/command-line-reference.markdown
+++ b/source/docs/en/1.2.0/cli/command-line-reference.markdown
@@ -78,7 +78,7 @@ The following details all the available options in the command line interface. T
                                (e.g. duration:10, frame:300, pts:900000)
        --stop-at  <string:number>
                                Stop encoding at a given duration (in seconds),
-                               frame, or pts (on a 90kHz clock)
+                               frame, or pts (on a 90kHz clock). Relative to --start-at
                                (e.g. duration:10, frame:300, pts:900000)
     
     


### PR DESCRIPTION
The documentation does not state that --stop-at is actually relative to --start-at.  
i.e If you want 60 seconds, from 1 minute in, you would according to the WRONG info write
--start-at duration:60 --stop-at duration:120.  
That would however get you 2 minutes, from the 1 minute mark.  

The correct usage, as clarified with this edit is
--start-at duration:60 --stop-at duration:60