### PR TITLE
docs: lbzip2 is part of the fedora dependencies

### DIFF
--- a/source/docs/de/1.2.0/developer/install-dependencies-fedora.markdown
+++ b/source/docs/de/1.2.0/developer/install-dependencies-fedora.markdown
@@ -36,6 +36,7 @@ Dependencies:
 - harfbuzz-devel
 - jansson-devel
 - lame-devel
+- lbzip2
 - libass-devel
 - libogg-devel
 - libsamplerate-devel
@@ -75,7 +76,7 @@ Abhängigkeiten installieren:
 
     sudo yum update
     sudo yum groupinstall "Development Tools" "Development Libraries"
-	sudo yum install bzip2-devel cmake fontconfig-devel freetype-devel fribidi-devel gcc-c++ git harfbuzz-devel jansson-devel lame-devel libass-devel libogg-devel libsamplerate-devel libtheora-devel libtool libvorbis-devel libxml2-devel m4 make nasm opus-devel patch python speex-devel tar xz-devel yasm zlib-devel
+	sudo yum install bzip2-devel cmake fontconfig-devel freetype-devel fribidi-devel gcc-c++ git harfbuzz-devel jansson-devel lame-devel lbzip2 libass-devel libogg-devel libsamplerate-devel libtheora-devel libtool libvorbis-devel libxml2-devel m4 make nasm opus-devel patch python speex-devel tar xz-devel yasm zlib-devel
  
 Installiere das freie [RPM Fusion](http://rpmfusion.org) Repository und zugehörige Abhängigkeiten.
 

--- a/source/docs/en/1.2.0/developer/install-dependencies-fedora.markdown
+++ b/source/docs/en/1.2.0/developer/install-dependencies-fedora.markdown
@@ -36,6 +36,7 @@ Dependencies:
 - harfbuzz-devel
 - jansson-devel
 - lame-devel
+- lbzip2
 - libass-devel
 - libogg-devel
 - libsamplerate-devel
@@ -75,7 +76,7 @@ Install dependencies.
 
     sudo yum update
     sudo yum groupinstall "Development Tools" "Development Libraries"
-    sudo yum install bzip2-devel cmake fontconfig-devel freetype-devel fribidi-devel gcc-c++ git harfbuzz-devel jansson-devel lame-devel libass-devel libogg-devel libsamplerate-devel libtheora-devel libtool libvorbis-devel libxml2-devel m4 make nasm opus-devel patch python speex-devel tar xz-devel yasm zlib-devel
+    sudo yum install bzip2-devel cmake fontconfig-devel freetype-devel fribidi-devel gcc-c++ git harfbuzz-devel jansson-devel lame-devel lbzip2 libass-devel libogg-devel libsamplerate-devel libtheora-devel libtool libvorbis-devel libxml2-devel m4 make nasm opus-devel patch python speex-devel tar xz-devel yasm zlib-devel
 
 Install the [RPM Fusion](http://rpmfusion.org) Free repository and related additional dependencies.
 

--- a/source/docs/en/latest/developer/install-dependencies-fedora.markdown
+++ b/source/docs/en/latest/developer/install-dependencies-fedora.markdown
@@ -36,6 +36,7 @@ Dependencies:
 - harfbuzz-devel
 - jansson-devel
 - lame-devel
+- lbzip2
 - libass-devel
 - libogg-devel
 - libsamplerate-devel
@@ -76,7 +77,7 @@ Install dependencies.
 
     sudo dnf update
     sudo dnf groupinstall "Development Tools" "Development Libraries"
-    sudo dnf install bzip2-devel cmake fontconfig-devel freetype-devel fribidi-devel gcc-c++ git harfbuzz-devel jansson-devel lame-devel libass-devel libogg-devel libsamplerate-devel libtheora-devel libtool libvorbis-devel libxml2-devel libvpx-devel m4 make nasm opus-devel patch python speex-devel tar xz-devel yasm zlib-devel
+    sudo dnf install bzip2-devel cmake fontconfig-devel freetype-devel fribidi-devel gcc-c++ git harfbuzz-devel jansson-devel lame-devel lbzip2 libass-devel libogg-devel libsamplerate-devel libtheora-devel libtool libvorbis-devel libxml2-devel libvpx-devel m4 make nasm opus-devel patch python speex-devel tar xz-devel yasm zlib-devel
 
 Install the [RPM Fusion](http://rpmfusion.org) Free repository and related additional dependencies.
 


### PR DESCRIPTION
when using minimal fedora (like image containers) lbzip2 is not present, so it should be added to the list of package dependencies. 