### PR TITLE
Trivial grammar correction

### DIFF
--- a/source/docs/en/latest/developer/build-linux.markdown
+++ b/source/docs/en/latest/developer/build-linux.markdown
@@ -53,5 +53,5 @@ To start over, simply remove the `build` directory.
 
 ## Building Intel MediaSDK (QSV support only)
 
-For Quick Sync Video support, the Intel MediaSDK and it's dependencies must be built and installed separately.  [Intel MediaSDK Build Instructions](https://github.com/Intel-Media-SDK/MediaSDK#how-to-build), and [Releases](https://github.com/Intel-Media-SDK/MediaSDK/releases) are available on their GitHub repository.  MediaSDK dependencies are listed on the releases page.
+For Quick Sync Video support, the Intel MediaSDK and its dependencies must be built and installed separately.  [Intel MediaSDK Build Instructions](https://github.com/Intel-Media-SDK/MediaSDK#how-to-build), and [Releases](https://github.com/Intel-Media-SDK/MediaSDK/releases) are available on their GitHub repository.  MediaSDK dependencies are listed on the releases page.
 


### PR DESCRIPTION
Corrects the usage of `it's` (contraction of `it` and `is/has`) to `its` (possessive).
Astonishingly, there's a website dedicated to this very issue, for those interested in further reading: [It's not Its](http://its-not-its.info)