### PR TITLE
Update docs to include option to name subtitle tracks

### DIFF
--- a/source/docs/de/1.3.0/cli/command-line-reference.markdown
+++ b/source/docs/de/1.3.0/cli/command-line-reference.markdown
@@ -545,6 +545,8 @@ Die folgende Auflistung zeigt alle verfügbaren Optionen für das Kommandozeilen
                                or less is selected. This should locate subtitles
                                for short foreign language segments. Best used in
                                conjunction with --subtitle-forced.
+      -S, --subname <string>   Set subtitle track name(s).
+                               Separate tracks by commas.
       -F, --subtitle-forced[=string]
                                Only display subtitles from the selected stream
                                if the subtitle has the forced flag set. The

--- a/source/docs/en/1.3.0/cli/command-line-reference.markdown
+++ b/source/docs/en/1.3.0/cli/command-line-reference.markdown
@@ -566,6 +566,8 @@ The following details all the available options in the command line interface. T
                                or less is selected. This should locate subtitles
                                for short foreign language segments. Best used in
                                conjunction with --subtitle-forced.
+      -S, --subname <string>   Set subtitle track name(s).
+                               Separate tracks by commas.
       -F, --subtitle-forced[=string]
                                Only display subtitles from the selected stream
                                if the subtitle has the forced flag set. The

--- a/source/docs/en/latest/cli/command-line-reference.markdown
+++ b/source/docs/en/latest/cli/command-line-reference.markdown
@@ -566,6 +566,8 @@ The following details all the available options in the command line interface. T
                                or less is selected. This should locate subtitles
                                for short foreign language segments. Best used in
                                conjunction with --subtitle-forced.
+      -S, --subname <string>   Set subtitle track name(s).
+                               Separate tracks by commas.
       -F, --subtitle-forced[=string]
                                Only display subtitles from the selected stream
                                if the subtitle has the forced flag set. The


### PR DESCRIPTION
As of https://github.com/HandBrake/HandBrake/commit/a1b407bc341c493aa027d526faeb3404e085e8a0, the CLI has had the option to name the subtitle tracks, but the documentation doesn't mention it.  This PR uses nearly identical language as the similar option to name audio tracks.