### PR TITLE
Add HDR10 and Universal Binary 2 for macOS

### DIFF
--- a/source/docs/en/latest/table-of-contents.markdown
+++ b/source/docs/en/latest/table-of-contents.markdown
@@ -131,6 +131,7 @@ Table of contents
 - Video
   - [Video codecs](technical/video-codecs.html)<span class="notice draft"><span>draft</span></span>
   - [10/12-bit encoding](technical/video-bit-depth.html)<span class="notice draft"><span>draft</span></span>
+  - [HDR10 encoding](technical/hdr10.html)<span class="notice draft"><span>draft</span></span>
   - [Constant quality versus average bit rate](technical/video-cq-vs-abr.html)<span class="notice draft"><span>draft</span></span>
   - [Presets and tunes](technical/video-presets-tunes.html)<span class="notice draft"><span>draft</span></span>
   - [Profiles and levels](technical/video-profiles-levels.html)<span class="notice draft"><span>draft</span></span>

--- a/source/docs/en/latest/technical/hdr10.markdown
+++ b/source/docs/en/latest/technical/hdr10.markdown
@@ -1,0 +1,35 @@
+---
+Type:            article
+Title:           HDR10 encoding.
+Project:         HandBrake
+Project_URL:     https://handbrake.fr/
+Project_Version: Latest
+Language:        English
+Language_Code:   en
+Authors:         [ Nomis101 ]
+Copyright:       2021 HandBrake Team
+License:         Creative Commons Attribution-ShareAlike 4.0 International
+License_Abbr:    CC BY-SA 4.0
+License_URL:     https://handbrake.fr/docs/license.html
+---
+
+HDR10 encoding 
+===================
+
+## Supported Encoders
+
+All encoders that support 10-bit encoding are also capable of HDR10 encoding. The follow encoders support higher than 8-bit.
+
+| Encoder             |
+|---------------------|
+| x264                |
+| x265                |
+| Intel QuickSync     |
+| Apple Video Toolbox |
+
+HandBrake will automatically passthru mastering display metadata and content light metadata from the source video to to final encode. For x265 encodings, HandBrake will also set the hdr-opt flag for you.
+
+### Limitations
+
+HandBrake will only handle HDR10 metadata. HDR10+ and Dolby Vision is currently not supported.
+

--- a/source/docs/en/latest/technical/system-requirements.markdown
+++ b/source/docs/en/latest/technical/system-requirements.markdown
@@ -103,7 +103,7 @@ See [Where to get HandBrake](../get-handbrake/where-to-get-handbrake.html), [Bui
 
 ### Mac
 
-HandBrake is supported on recent versions of macOS[^apple-eol].
+Since version 1.4.0 HandBrake for macOS is shipped as a Universal Binary 2 (x86_64 / arm64). HandBrake is supported on recent versions of macOS[^apple-eol].
 
 | macOS Version      | Status              | Last Compatible Version | Notes                              |
 |--------------------|---------------------|-------------------------|------------------------------------|


### PR DESCRIPTION
I've tried to add a simple draft for HDR10 encoding. I used the video-bit-depth as a blueprint for that. And I've added information about the new UB2 for Mac. Hope thats fine.

How can I check, if this commit is GPG signed or not?