### PR TITLE
Add some text to filters summary, add Chroma Smooth and Colorspace filter

### DIFF
--- a/source/docs/en/latest/table-of-contents.markdown
+++ b/source/docs/en/latest/table-of-contents.markdown
@@ -138,6 +138,7 @@ Table of contents
   - [Video angles](technical/video-angles.html)<span class="notice draft"><span>draft</span></span>
   - [Anamorphic video](technical/anamorphic-guide.html)<span class="notice draft"><span>draft</span></span>
   - [Frame rate](technical/frame-rates.html)<span class="notice draft"><span>draft</span></span>
+  - [Filters](technical/filters-summary.html)<span class="notice draft"><span>draft</span></span>
 - Hardware encoders
   - [AMD VCE](technical/video-vce.html)
   - [Apple VideoToolbox](technical/video-videotoolbox.html)

--- a/source/docs/en/latest/technical/filters-summary.markdown
+++ b/source/docs/en/latest/technical/filters-summary.markdown
@@ -17,7 +17,6 @@ License_URL:     https://handbrake.fr/docs/license.html
 Summary of Filters
 =============================
 
-Coming Soon!
 
 HandBrake contains the following filters:
 
@@ -26,5 +25,76 @@ HandBrake contains the following filters:
   - Decomb
 - Denoise
 - Deblock
+- Chroma Smooth
 - Grayscale
-- Rotation
+- Colorspace
+
+
+Detelecine
+----------
+
+Detelecine removes comb artifacts that are the result of telecine, a process for converting film frame rates to television frame rates.
+
+
+Deinterlace
+-----------
+
+Deinterlace removes comb artifacts from the picture. 
+Yadif is a popular and fast deinterlacer. 
+Decomb switches between multiple interpolation algorithms for speed and quality.
+
+The following Deinterlace tunes are available:
+- Default: Is well balanced for speed and quality.
+- Skip Spatial Check: Lets Yadif skip correcting certain avoidable artifacts for a slight speed boost.
+- EEDI2: Uses a slower, higher quality interpolation algorithm for Decomb. Useful for the most difficult sources.
+- Bob: Attempts to better preserve motion for a slight penalty to perceived resolution.
+
+
+Denoise
+-------
+
+Denoise reduces or removes the appearance of noise and grain. This can improve compression efficiency and create higher quality video at smaller file sizes. 
+Overly strong Denoise settings may damage picture quality by discarding detail.
+
+NLMeans is a high quality denoise filter with a cost to speed. Use where quality is more important than speed.
+HQDN3D is an adaptive low-pass filter, faster than NLMeans but less effective at preserving fine detail.
+
+The following Denoise tunes are available:
+- None: Uses the default preset settings.
+- Film: Refines settings for use with most live action content.
+- Grain: Only processes color channels. Useful for preserving the film-like look of luminance grain while reducing or removing color noise.
+- High Motion: Reduces color smearing in high motion scenes by avoiding temporal processing for color channels. Useful for sports and action videos.
+- Animation: Is useful for cel animation such as anime and cartoons.
+- Tape: Is useful for low-detail analog tape sources such as VHS, where Film does not produce a desirable result.
+- Sprite: Is useful for 1-/4-/8-/16-bit 2-dimensional games. Sprite is not designed for high definition video.
+
+
+Deblock
+-------
+
+Deblock reduces blocky artifacts caused by low quality video compression.
+
+
+Chroma Smooth
+-------------
+
+Reduces chroma noise, rainbows, and other prominent visual artifacts. Useful for resolving various color-related issues, especially with lower resolution content from analog sources, e.g. not great DVD and VHS sources. The blurring/smoothing algorithm is the same as used by the unsharp filter.
+
+
+Grayscale
+---------
+
+Grayscale removes the color component of the video. Often referred to as Black & White video.
+
+
+Colorspace
+----------
+
+Colorspace + tonemap filter. Can change/tonemap the colorspace of the video into one of the following:
+
+- BT.2020
+- BT.709
+- BT.601 SMPTE-C
+- BT.601 EBU
+
+If this set to "Off" then HandBrake will keep the colorspace of the video.

--- a/source/docs/en/latest/technical/filters-summary.markdown
+++ b/source/docs/en/latest/technical/filters-summary.markdown
@@ -59,7 +59,7 @@ Overly strong Denoise settings may damage picture quality by discarding detail.
 NLMeans is a high quality denoise filter with a cost to speed. Use where quality is more important than speed.
 HQDN3D is an adaptive low-pass filter, faster than NLMeans but less effective at preserving fine detail.
 
-The following Denoise tunes are available:
+For NLMeans the following Denoise tunes are available:
 - None: Uses the default preset settings.
 - Film: Refines settings for use with most live action content.
 - Grain: Only processes color channels. Useful for preserving the film-like look of luminance grain while reducing or removing color noise.
@@ -78,7 +78,7 @@ Deblock reduces blocky artifacts caused by low quality video compression.
 Chroma Smooth
 -------------
 
-Reduces chroma noise, rainbows, and other prominent visual artifacts. Useful for resolving various color-related issues, especially with lower resolution content from analog sources, e.g. not great DVD and VHS sources. The blurring/smoothing algorithm is the same as used by the unsharp filter.
+Reduces chroma noise, rainbows, and other prominent visual artifacts. Useful for resolving various color-related issues, especially with lower resolution content from analog sources, e.g. poor quality DVD and VHS sources. The blurring/smoothing algorithm is the same as used by the unsharp filter.
 
 
 Grayscale


### PR DESCRIPTION
I've added the new Chroma Smooth and Colorspace filter to the filters summary. Because there was no text yet for the other filters, I added some. I just copied the explanation texts from HandBrake app, because there is no way I could describe this better in my own words. For the Chroma Smooth filter I've added Bradley's explanation from the Bug. I removed the Rotation filter, because it was removed from the filters tab. Didn't know where to add it instead (I could' find a description of the Overview tab).
Because the filters were not referenced in the table-of-contents, I've added it there.