### PR TITLE
[Fix] Add an option argument <float> to the -R/-arate option

### DIFF
--- a/source/docs/en/latest/cli/command-line-reference.markdown
+++ b/source/docs/en/latest/cli/command-line-reference.markdown
@@ -265,7 +265,7 @@ The following details all the available options in the command line interface. T
                   <string>     Separate tracks by commas.
                                0 = Disable Normalization (default)
                                1 = Enable Normalization
-       -R, --arate             Set audio samplerate(s)
+       -R, --arate <float>     Set audio samplerate(s)
                                (8/11.025/12/16/22.05/24/32/44.1/48 kHz)
                                or "auto". Separate tracks by commas.
        -D, --drc <float>       Apply extra dynamic range compression to the


### PR DESCRIPTION
According to [the description](https://handbrake.fr/docs/en/latest/cli/command-line-reference.html#:~:text=--arate) and [the implementation](https://github.com/HandBrake/HandBrake/blob/cd3a400c44d43f282d8c9e729a74150a9c086ae7/test/test.c#L2337
), the -arate option takes an argument (maybe `<float>`).
