### PR TITLE
featherlight js: Handle very wide aspect images

### DIFF
--- a/templates/mark1/assets/js/scripts.js
+++ b/templates/mark1/assets/js/scripts.js
@@ -247,8 +247,8 @@ $(document).ready(function(){
             if (ratio > 1) {
                 /* Round ratio down so height calc works */
                 ratio = h / Math.floor(h / ratio);
-                /* Account for caption size */
-                if (height + (caption_height * 2) > parent_height){
+                /* Account for caption size, except short images */
+                if (height > 300 && height + (caption_height * 2) > parent_height){
                     caption_factor = caption_factor - (caption_height * 2.5 / parent_height);
                 }
                 new_width  = w * caption_factor / ratio;


### PR DESCRIPTION
The current resizing logic attempts to correct for caption height when resizing images, but this breaks on very wide aspects, where the caption height overpowers the height of the image itself. When caption correction is applied to such images (like the toolbar screenshots), they render _smaller_ in the lightbox than embedded in the documentation!

This PR limits the "caption correction" to only be applied on images over 300px tall, avoiding such issues.

Before:
![image](https://user-images.githubusercontent.com/538020/134265669-43285d45-82f0-4729-b5bb-03aae711a292.png)

After (same size window):
![image](https://user-images.githubusercontent.com/538020/134266038-7219c232-9f9c-4152-b9d6-98120ae98cc6.png)
