### PR TITLE
Some quality-of-life fixes for marsh

### DIFF
--- a/marsh
+++ b/marsh
@@ -1724,7 +1724,7 @@ function build_document {  # build_document dest_dir target_dir document advance
         # process images with multiple resolution assets
         cp "${DOCUMENT}.${MARSH_UID}.document" "${DOCUMENT}.${MARSH_UID}.document.temp"
         <"${DOCUMENT}.${MARSH_UID}.document.temp" sed -E \
-        -e 's|^!\[(.+)]\([ ]*([^ ]+)[ ]*"(.+)"[ ]*\)$|<figure><a href="\2"><img src="\2" alt="\1" /></a><figcaption>\3</figcaption></figure>|' |
+        -e 's|^!\[(.+)]\([ ]*([^ ]+)[ ]*"(.+)"[ ]*\)$|<figure>\n<a href="\2">\n<img src="\2" alt="\1" />\n</a>\n<figcaption>\3</figcaption>\n</figure>|' |
         process_markdown |
         sed -E \
         -e 's|<p><figure>|<figure>|' \
@@ -1733,7 +1733,7 @@ function build_document {  # build_document dest_dir target_dir document advance
         {
             if ($0 ~ " src=\"[^\"]+\"")
             {
-                split($0, a, " ");
+                split($0, a, " ", ws);
                 for(i=1; i<=length(a); i++)
                 {
                     if (a[i] ~ "^src=\"[^\"]+\"$")
@@ -1758,11 +1758,11 @@ function build_document {  # build_document dest_dir target_dir document advance
                         } else {
                             f3="";
                         }
-                        print "src=\"" f "\" srcset=\"" f1 f2 f3 "\" ";
-                    } else {
-                        print a[i];
+                        a[i] = "src=\"" f "\" srcset=\"" f1 f2 f3 "\"";
                     }
+                printf "%s%s", a[i], ws[i];
                 }
+                printf "\n";
             } else {
                 print $0;
             }

--- a/marsh
+++ b/marsh
@@ -1089,7 +1089,7 @@ function build_template {  # build_template dest_dir target_dir document templat
         for ITEM in ${LIST[@]}; do
             cp "${FILE}" "${FILE_TEMP}"
             <"${FILE_TEMP}" \
-            awk '/^[ ]*\{\%[ ]*if[ ]+'${TAG//\./\.}'[ ]+'${COMPARITOR// /[ ]+}'[ ]+"'${ITEM}'"[ ]*\%\}[ ]*$/ {
+            awk '/^[ ]*\{%[ ]*if[ ]+'${TAG//\./\.}'[ ]+'${COMPARITOR// /[ ]+}'[ ]+"'${ITEM}'"[ ]*%\}[ ]*$/ {
                     tag=1;
                     line=1;
                     delete buffer;
@@ -1097,16 +1097,16 @@ function build_template {  # build_template dest_dir target_dir document templat
                 {
                     buffer[line++]=$0;
                 }
-                (tag==1 && (/^[ ]*\{\%[ ]*endif[ ]*\%\}[ ]*$/ || /^[ ]*\{\%[ ]*else[ ]*\%\}[ ]*$/)) {
+                (tag==1 && (/^[ ]*\{%[ ]*endif[ ]*%\}[ ]*$/ || /^[ ]*\{%[ ]*else[ ]*%\}[ ]*$/)) {
                     for (i=2; i < line-1; i++) {
                         print buffer[i];
                     }
                 }
-                (tag>0 && /^[ ]*\{\%[ ]*else[ ]*\%\}[ ]*$/) {
+                (tag>0 && /^[ ]*\{%[ ]*else[ ]*%\}[ ]*$/) {
                     tag=2;
                     next;
                 }
-                (tag>0 && /^[ ]*\{\%[ ]*endif[ ]*\%\}[ ]*$/) {
+                (tag>0 && /^[ ]*\{%[ ]*endif[ ]*%\}[ ]*$/) {
                     tag=0;
                     next;
                 }
@@ -1118,7 +1118,7 @@ function build_template {  # build_template dest_dir target_dir document templat
         # process else
         cp "${FILE}" "${FILE_TEMP}"
         <"${FILE_TEMP}" \
-        awk '/^[ ]*\{\%[ ]*if[ ]+'${TAG//\./\.}'[ ]+'${COMPARITOR// /[ ]+}'[ ]+".+"[ ]*\%\}[ ]*$/ {
+        awk '/^[ ]*\{%[ ]*if[ ]+'${TAG//\./\.}'[ ]+'${COMPARITOR// /[ ]+}'[ ]+".+"[ ]*%\}[ ]*$/ {
                 tag=1;
                 line=1;
                 delete buffer;
@@ -1129,16 +1129,16 @@ function build_template {  # build_template dest_dir target_dir document templat
             (tag==1) {
                 delete buffer;
             }
-            (tag==2 && /^[ ]*\{\%[ ]*endif[ ]*\%\}[ ]*$/) {
+            (tag==2 && /^[ ]*\{%[ ]*endif[ ]*%\}[ ]*$/) {
                 for (i=2; i < line-1; i++) {
                     print buffer[i];
                 }
             }
-            (tag>0 && /^[ ]*\{\%[ ]*else[ ]*\%\}[ ]*$/) {
+            (tag>0 && /^[ ]*\{%[ ]*else[ ]*%\}[ ]*$/) {
                 tag=2;
                 next;
             }
-            (tag>0 && /^[ ]*\{\%[ ]*endif[ ]*\%\}[ ]*$/) {
+            (tag>0 && /^[ ]*\{%[ ]*endif[ ]*%\}[ ]*$/) {
                 tag=0;
                 next;
             }
@@ -1154,7 +1154,7 @@ function build_template {  # build_template dest_dir target_dir document templat
         FILE_TEMP=$(mktemp "${MARSH_TEMP}/conditional-XXXXXX")
         # remove unsupported conditionals
         cp "${FILE}" "${FILE_TEMP}"
-        <"${FILE_TEMP}" awk '/^[ ]*\{\%[ ]*if[^%]+\%\}[ ]*$/ {k=1;i=1;delete a} {a[i++]=$0} (k==1 && /^[ ]*\{\%[ ]*endif[ ]*\%\}[ ]*$/) {k=0;next} (k==0) { print }' > "${FILE}"
+        <"${FILE_TEMP}" awk '/^[ ]*\{%[ ]*if[^%]+%\}[ ]*$/ {k=1;i=1;delete a} {a[i++]=$0} (k==1 && /^[ ]*\{%[ ]*endif[ ]*%\}[ ]*$/) {k=0;next} (k==0) { print }' > "${FILE}"
         return 0
     }
 

--- a/marsh
+++ b/marsh
@@ -2233,7 +2233,7 @@ for I in "${!MARKDOWN_OPTIONS[@]}"; do
 done
 OIFS="${IFS}"
 IFS=$'\n'
-MARKDOWN_UNKNOWN=($(echo "test options" | "${MARKDOWN}" ${MARKDOWN_OPTIONS[@]} -VV 2>&1 >/dev/null | grep -i "unknown" | sed -E -e 's/^markdown: unknown option <([^>]+)>$/\1/'))
+MARKDOWN_UNKNOWN=($("${MARKDOWN}" ${MARKDOWN_OPTIONS[@]} -VV 2>&1 >/dev/null | grep -i "unknown" | sed -E -e 's/^markdown: unknown option <([^>]+)>$/\1/'))
 IFS="${OIFS}"
 if [[ "${#MARKDOWN_UNKNOWN[@]}" -gt 0 ]]; then
     echo -n "Unknown markdown options:" >&2


### PR DESCRIPTION
* Remove the escaping on `%` signs in regular expressions. (Clears up the copious "warning: regexp escape sequence `\%' is not a known regexp operator" spew when run.)
* Remove the `echo "test options"` at the start of the `MARKDOWN_OPTIONS` validation pipeline. (discount is being run with `-VV`, a mode in which it doesn't accept input. Clears up the broken-pipe spew when running in Github Actions.)
* Rewrite the `awk` script that replaces image embeds to output more readable HTML, by not outputting every split token on a separate line when word-splitting is performed.

Source comparison on the third change, for example...

Before:
```html
<figure><a
href="../../images/mac/add-to-queue-button-1.0.0.png"><img
src="../../images/mac/add-to-queue-button-1.0.0.png" srcset="../../images/mac/add-to-queue-button-1.0.0.png 1x" 
alt="Adding
an
encode
to
the
Queue"
/></a><figcaption>Select
the
Add
to
Queue
button
on
the
toolbar
to
add
your
encode
to
the
queue.</figcaption></figure>
```

After:
```html
<figure>
<a href="../../images/mac/add-to-queue-button-1.0.0.png">
<img src="../../images/mac/add-to-queue-button-1.0.0.png" srcset="../../images/mac/add-to-queue-button-1.0.0.png 1x" alt="Adding an encode to the Queue" />
</a>
<figcaption>Select the Add to Queue button on the toolbar to add your encode to the queue.</figcaption>
</figure>
```