### PR TITLE
breadcrumbs: Use &gt HTML entity for '>'

### DIFF
--- a/templates/mark1/partials/nav.html
+++ b/templates/mark1/partials/nav.html
@@ -1,5 +1,5 @@
 <nav>
-    <div class="breadcrumbs"><a href="{{ base.relpath }}">Docs</a><span class="language-separator" hidden>&nbsp;> </span><span class="language" hidden><a href="{{ base.relpath }}{{ document.language-code | slug }}/">{{ document.language }}</a></span><span class="version-separator" hidden>&nbsp;> </span><span class="version" hidden><a class="version" href="{{ base.relpath }}{{ document.language-code | slug }}/{{ document.project-version | slug }}/">{{ document.project }} {{ document.project-version }}</a></span>&nbsp;> {{ document.title }}</div>
+    <div class="breadcrumbs"><a href="{{ base.relpath }}">Docs</a><span class="language-separator" hidden>&nbsp;&gt; </span><span class="language" hidden><a href="{{ base.relpath }}{{ document.language-code | slug }}/">{{ document.language }}</a></span><span class="version-separator" hidden>&nbsp;&gt; </span><span class="version" hidden><a class="version" href="{{ base.relpath }}{{ document.language-code | slug }}/{{ document.project-version | slug }}/">{{ document.project }} {{ document.project-version }}</a></span>&nbsp;&gt; {{ document.title }}</div>
     <div class="navigation" hidden>
         {{ navigation }}
     </div>


### PR DESCRIPTION
The breadcrumbs template was using a raw `>` character to separate the navigation levels, which technically isn't valid HTML. This PR replaces each `>` that isn't the end of a tag with the equivalent HTML entity, `&gt;`.