### PR TITLE
marsh: More comfortable source formatting

### DIFF
--- a/marsh
+++ b/marsh
@@ -1724,7 +1724,7 @@ function build_document {  # build_document dest_dir target_dir document advance
         # process images with multiple resolution assets
         cp "${DOCUMENT}.${MARSH_UID}.document" "${DOCUMENT}.${MARSH_UID}.document.temp"
         <"${DOCUMENT}.${MARSH_UID}.document.temp" sed -E \
-        -e 's|^!\[(.+)]\([ ]*([^ ]+)[ ]*"(.+)"[ ]*\)$|<figure><a href="\2"><img src="\2" alt="\1" /></a><figcaption>\3</figcaption></figure>|' |
+        -e 's|^!\[(.+)]\([ ]*([^ ]+)[ ]*"(.+)"[ ]*\)$|<figure>\n<a href="\2">\n<img src="\2" alt="\1" />\n</a>\n<figcaption>\3</figcaption>\n</figure>|' |
         process_markdown |
         sed -E \
         -e 's|<p><figure>|<figure>|' \
@@ -1758,11 +1758,15 @@ function build_document {  # build_document dest_dir target_dir document advance
                         } else {
                             f3="";
                         }
-                        print "src=\"" f "\" srcset=\"" f1 f2 f3 "\" ";
-                    } else {
-                        print a[i];
+                        a[i] = "src=\"" f "\" srcset=\"" f1 f2 f3 "\"";
                     }
+		    if (i > 1)
+		    {
+		        printf " ";
+		    }
+                    printf "%s", a[i];
                 }
+                printf "\n";
             } else {
                 print $0;
             }


### PR DESCRIPTION
- Add newlines between tags in the inserted <figure> markup
- Use printf instead of print when looping over split lines in awk,
  otherwise each word ends up on a separate line

This replaces the remaining commit from PR #143, which used `gawk` instructions incompatible with the limited BSD `awk` on macOS. The `awk` code in this PR avoids any `gawk`-isms.