### PR TITLE
Specify a compiler for FreeBSD as modern releases use Clang

### DIFF
--- a/source/docs/en/latest/developer/build-bsd.markdown
+++ b/source/docs/en/latest/developer/build-bsd.markdown
@@ -36,7 +36,7 @@ Build HandBrake. To enable experimental support for Intel Quick Sync Video, appe
 
 For FreeBSD
 
-    ./configure --launch-jobs=$(sysctl -n hw.ncpu) --launch
+    env CC=cc ./configure --launch-jobs=$(sysctl -n hw.ncpu) --launch
 
 For NetBSD
 


### PR DESCRIPTION
As in 10.x, 11.x, 12.x, 13.x, etc.