### PR TITLE
Update Links to Microsoft .Net Desktop Runtime

### DIFF
--- a/source/docs/en/1.6.0/get-handbrake/download-and-install.markdown
+++ b/source/docs/en/1.6.0/get-handbrake/download-and-install.markdown
@@ -146,7 +146,7 @@ Next, the installer will ask you where you wish to install HandBrake. Unless you
 
 You will find shortcuts for launching HandBrake placed on both the Windows Desktop and Start Menu.
 
-If you do not already have Microsoft .NET Desktop Runtime 6.0 installed, you will also need to install this from the [Microsoft .NET Desktop Runtime Download Page](https://dotnet.microsoft.com/en-us/download/dotnet/thank-you/runtime-desktop-6.0.4-windows-x64-installer)
+If you do not already have Microsoft .NET Desktop Runtime 6.0 installed, you will also need to install this from the [Microsoft .NET Desktop Runtime Download Page](https://dotnet.microsoft.com/en-us/download/dotnet/thank-you/runtime-desktop-6.0.20-windows-x64-installer)
 
 <!-- /.system-windows -->
 

--- a/source/docs/en/latest/get-handbrake/download-and-install.markdown
+++ b/source/docs/en/latest/get-handbrake/download-and-install.markdown
@@ -146,7 +146,7 @@ Next, the installer will ask you where you wish to install HandBrake. Unless you
 
 You will find shortcuts for launching HandBrake placed on both the Windows Desktop and Start Menu.
 
-If you do not already have Microsoft .NET Desktop Runtime 6.0 installed, you will also need to install this from the [Microsoft .NET Desktop Runtime Download Page](https://dotnet.microsoft.com/en-us/download/dotnet/thank-you/runtime-desktop-6.0.4-windows-x64-installer)
+If you do not already have Microsoft .NET Desktop Runtime 6.0 installed, you will also need to install this from the [Microsoft .NET Desktop Runtime Download Page](https://dotnet.microsoft.com/en-us/download/dotnet/thank-you/runtime-desktop-6.0.20-windows-x64-installer)
 
 <!-- /.system-windows -->
 


### PR DESCRIPTION
The Link to Microsoft .NET Desktop Runtime link to very old version 6.0.4.
Current is 6.0.20 which contain very important security fixes. [1]

I don't know how the official handbrake website is based on the docs, **but it also links to the old 6.0.4.** If someone is in contact with the webmaster he should be informed.

[1] https://github.com/dotnet/core/blob/main/release-notes/6.0/6.0.20/6.0.20.md