### PR TITLE
Correct minor grammar mistake

### DIFF
--- a/source/docs/en/latest/technical/old-ipod-support.markdown
+++ b/source/docs/en/latest/technical/old-ipod-support.markdown
@@ -23,5 +23,5 @@ Older classic iPods require a special atom to be written to the MP4 file before 
 
 HandBrake doesn't add this by default, but if you have an older classic iPod, you can turn it on by selecting the "iPod 5G Support" checkbox located under the Destination chooser.
 
-This is only available for MP4 files
+This is only available for MP4 files.
 


### PR DESCRIPTION
I spotted a minor grammar mistake (missing punctuation) at [this page](https://handbrake.fr/docs/en/1.9.0/technical/old-ipod-support.html) and wanted to help fix it.

I'm a noob to the HandBrake documentation repo, so I apologize if I made a mistake in my filing of this pull request.
Have a great day every day,
PPPDUD