### PR TITLE
docs: update Intel QSV documentation with the proper generation name in latest

### DIFF
--- a/source/docs/en/latest/technical/video-qsv.markdown
+++ b/source/docs/en/latest/technical/video-qsv.markdown
@@ -18,7 +18,7 @@ Intel Quick Sync Video
 
 ## Supported Hardware and Configurations
 
-- Intel Skylake (9th Generation Core) CPU or later with Intel HD, Iris Xe or Arc graphics.
+- Intel Coffee Lake (9th Generation Core) CPU or later with Intel HD, Iris Xe or Arc graphics.
 - Windows 10 or Later
   - Please make sure your Intel GPU drivers are up-to-date. Driver version should be >= 31.0.x.x
 - Some Modern Linux versions. 


### PR DESCRIPTION
Addressing an issue I opened: #243