### PR TITLE
subtitles.markdown: remove incorrect statement on ASS / SSA

### DIFF
--- a/source/docs/en/1.10.0/advanced/subtitles.markdown
+++ b/source/docs/en/1.10.0/advanced/subtitles.markdown
@@ -26,7 +26,7 @@ There are different types of subtitles that exist:
 
 - Bitmaps (Pictures), e.g. DVD VOBSUBs, Bluray PGS
 - Text with markup, e.g. Closed Captions and SRT files.
-- Styled SSA, e.g. most anime subtitles in MKV files
+- Styled ASS / SSA, e.g. most anime subtitles in MKV files
 
 HandBrake can read subtitles from the following sources:
 
@@ -65,10 +65,9 @@ The following subtitle types as supported as follows:
   - You can set an offset (measured in milliseconds) to change the start time that the first and subsequent SRT subtitles will appear. Use trial and error encoding a single chapter to obtain the correct offset.
   - You should make sure the correct character code is selected from the “Char Code” dropdown. Selecting the wrong code, will result in your output file having no subtitle track, and can cause the player to crash when playing that track.
 
-- SSA Subtitles
+- ASS / SSA Subtitles
   - SSA Subtitles can be passed-thru or burned into the video. 
   - When burned into the video, all styling (e.g. fonts, colors, etc) is preserved.
-    - Animated effects (e.g. fade in/out, karaoke) are not currently supported. (Only the middle frame of the animation will be used.)
   - When passed-thru as text, only bold/italic/underline styles are preserved. Some players may not support the simultaneous display of multiple passed-thru SSA subtitles.
 
 ## Forced Subtitles

--- a/source/docs/en/1.10.0/advanced/subtitles.markdown
+++ b/source/docs/en/1.10.0/advanced/subtitles.markdown
@@ -26,7 +26,7 @@ There are different types of subtitles that exist:
 
 - Bitmaps (Pictures), e.g. DVD VOBSUBs, Bluray PGS
 - Text with markup, e.g. Closed Captions and SRT files.
-- Styled ASS / SSA, e.g. most anime subtitles in MKV files
+- Styled SSA, e.g. most anime subtitles in MKV files
 
 HandBrake can read subtitles from the following sources:
 
@@ -65,9 +65,10 @@ The following subtitle types as supported as follows:
   - You can set an offset (measured in milliseconds) to change the start time that the first and subsequent SRT subtitles will appear. Use trial and error encoding a single chapter to obtain the correct offset.
   - You should make sure the correct character code is selected from the “Char Code” dropdown. Selecting the wrong code, will result in your output file having no subtitle track, and can cause the player to crash when playing that track.
 
-- ASS / SSA Subtitles
+- SSA Subtitles
   - SSA Subtitles can be passed-thru or burned into the video. 
   - When burned into the video, all styling (e.g. fonts, colors, etc) is preserved.
+    - Animated effects (e.g. fade in/out, karaoke) are not currently supported. (Only the middle frame of the animation will be used.)
   - When passed-thru as text, only bold/italic/underline styles are preserved. Some players may not support the simultaneous display of multiple passed-thru SSA subtitles.
 
 ## Forced Subtitles

--- a/source/docs/en/latest/advanced/subtitles.markdown
+++ b/source/docs/en/latest/advanced/subtitles.markdown
@@ -26,7 +26,7 @@ There are different types of subtitles that exist:
 
 - Bitmaps (Pictures), e.g. DVD VOBSUBs, Bluray PGS
 - Text with markup, e.g. Closed Captions and SRT files.
-- Styled SSA, e.g. most anime subtitles in MKV files
+- Styled ASS / SSA, e.g. most anime subtitles in MKV files
 
 HandBrake can read subtitles from the following sources:
 
@@ -65,11 +65,10 @@ The following subtitle types as supported as follows:
   - You can set an offset (measured in milliseconds) to change the start time that the first and subsequent SRT subtitles will appear. Use trial and error encoding a single chapter to obtain the correct offset.
   - You should make sure the correct character code is selected from the “Char Code” dropdown. Selecting the wrong code, will result in your output file having no subtitle track, and can cause the player to crash when playing that track.
 
-- SSA Subtitles
+- ASS / SSA Subtitles
   - SSA Subtitles can be passed-thru or burned into the video. 
   - When burned into the video, all styling (e.g. fonts, colors, etc) is preserved.
-    - Animated effects (e.g. fade in/out, karaoke) are not currently supported. (Only the middle frame of the animation will be used.)
-  - When passed-thru as text, only bold/italic/underline styles are preserved. Some players may not support the simultaneous display of multiple passed-thru SSA subtitles.
+  - When passed-thru with a crossconversion as text, only bold/italic/underline styles are preserved. Some players may not support the simultaneous display of multiple passed-thru SSA subtitles.
 
 ## Forced Subtitles
 


### PR DESCRIPTION
The burn-in functionality of ASS / SSA is fully functional and does not miss any "frame".